### PR TITLE
FIX: Restore BIDSLayout.__init__ interface, mark deprecated/notimplemented

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -187,7 +187,7 @@ class BIDSLayout(BIDSLayoutMRIMixin):
 
     def get(self, return_type: str = 'object', target: str = None, scope: str = None,
             extension: Union[str, List[str]] = None, suffix: Union[str, List[str]] = None,
-            regex_search=False,
+            regex_search=None,
             **entities) -> Union[List[str], List[object]]:
         """Retrieve files and/or metadata from the current Layout.
 
@@ -245,6 +245,8 @@ class BIDSLayout(BIDSLayoutMRIMixin):
         list of :obj:`bids.layout.BIDSFile` or str
             A list of BIDSFiles (default) or strings (see return_type).
         """
+        if regex_search is None:
+            regex_search = self._regex_search
         # Provide some suggestions if target is specified and invalid.
         self_entities = self.get_entities()
         if target is not None and target not in self_entities:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -83,7 +83,6 @@ class BIDSLayout(BIDSLayoutMRIMixin):
         self,
         root: Union[str, Path],
         validate: bool=True,
-        absolute_paths: bool=True,
         derivatives: bool=False,
         config: Optional[Union[str, List[str]]]=None,
         sources: Optional[List[Any]]=None,
@@ -101,7 +100,6 @@ class BIDSLayout(BIDSLayoutMRIMixin):
         self.validationReport = None
 
         self._regex_search = regex_search
-        self._absolute_paths = absolute_paths
 
         if validate:
             self.validationReport = self.validate()
@@ -216,11 +214,6 @@ class BIDSLayout(BIDSLayoutMRIMixin):
             Whether to require exact matching
             (False) or regex search (True) when comparing the query string
             to each entity.
-        absolute_paths : bool, optional
-            Optionally override the instance-wide option
-            to report either absolute or relative (to the top of the
-            dataset) paths. If None, will fall back on the value specified
-            at BIDSLayout initialization.
         invalid_filters (str): Controls behavior when named filters are
             encountered that don't exist in the database (e.g., in the case of
             a typo like subbject='0.1'). Valid values:


### PR DESCRIPTION
This PR is aimed at making `BIDSLayout` drop-in by replicating all old parameters. Some are marked deprecated or not-implemented.

Fixes #2.