### PR TITLE
Miscellanous clean up / fixes

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -278,8 +278,12 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
         except KeyError:
             pass
         if key.startswith('get_'):
-            ent_name = key.replace('get_', '')
-            ent_name = self.schema.fuzzy_match_entity_key(ent_name)
+            orig_ent_name = key.replace('get_', '')
+            ent_name = self.schema.fuzzy_match_entity_key(orig_ent_name)
+            if ent_name not in self.get_entities():
+                raise BIDSEntityError(
+                    "'get_{}' can't be called because '{}' isn't a "
+                    "recognized entity name.".format(orig_ent_name, orig_ent_name))
             return partial(self.get, return_type='id', target=ent_name)
         # Spit out default message if we get this far
         raise AttributeError("%s object has no attribute named %r" %

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -583,9 +583,10 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         if return_type in ("dir", "id"):
             # Resolve proper target names to their "key", e.g., session to ses
             # XXX should we allow ses?
-            target_match = getattr(self.dataset._schema.EntityEnum, target, None)
+            target_match = [e for e in self.dataset._schema.EntityEnum 
+                if target in [e.name, e.literal_]]
             potential = list(self.get_entities().keys())
-            if (not target_match) or target_match.name not in potential:
+            if (not target_match) or target_match[0].literal_ not in potential:
                 suggestions = difflib.get_close_matches(target, potential)
                 if suggestions:
                     message = "Did you mean one of: {}?".format(suggestions)
@@ -593,7 +594,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                     message = "Valid targets are: {}".format(potential)
                 raise TargetError(f"Unknown target '{target}'. {message}")  
         folder = self.dataset
-        result = query(folder, return_type, target_match.name, scope, extension, suffix, regex_search, **entities)
+        result = query(folder, return_type, target_match[0].name, scope, extension, suffix, regex_search, **entities)
         if return_type == 'files':
             result = natural_sort(result)
         if return_type == "object":

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -26,6 +26,7 @@ __all__ = ['BIDSLayout, Query']
 
 from ..utils import natural_sort, listify
 
+
 class BIDSLayoutWritingMixin:
     def build_path(self, source, path_patterns=None, strict=False,
                    scope='all', validate=True, absolute_paths=None):
@@ -189,7 +190,15 @@ class BIDSLayoutMRIMixin:
         return all_trs.pop()
 
 
-class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
+        from bids.variables import load_variables
+        index = load_variables(self, types=types, levels=level,
+                               skip_empty=skip_empty, **kwargs)
+        return index.get_collections(level, variables, merge,
+                                     sampling_rate=sampling_rate)
+
+
+
+class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariablesMixin):
     """A convenience class to provide access to an in-memory representation of a BIDS dataset.
 
     .. code-block::
@@ -215,6 +224,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
         database_path: Optional[str]=None,
         reset_database: Optional[bool]=None,
         indexer: Optional[Callable]=None,
+        absolute_paths: Optional[bool]=None,
         **kwargs,
     ):
         if isinstance(root, Path):
@@ -244,6 +254,11 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
         if indexer is not None:
             warnings.warn(
                 "indexer no longer has any effect and will be removed",
+                DeprecationWarning
+            )
+        if absolute_paths is not None:
+            warnings.warn(
+                "absolute_paths no longer has any effect and will be removed",
                 DeprecationWarning
             )
         if kwargs:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -363,7 +363,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         """
         path = convert_to_relative(self.dataset, path)
         file = self.dataset.get_file(path)
-        md = file.get_metadata(include_entities=include_entities, scope=scope)
+        md = file.get_metadata(include_entities=include_entities)
         bmd = BIDSMetadata(file.get_absolute_path())
         bmd.update(md)
         return bmd

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -402,8 +402,9 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         """
         results = parse_bids_name(filename)
 
-        ## Need to map entity literal to entity name
         entities = results.pop('entities')
+        schema_entities = {e.literal_: e.name for e in list(self.schema.EntityEnum)}
+        entities = {schema_entities[k]: v for k, v in entities.items()}
         results = {**entities, **results}
 
         if entities:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -266,11 +266,31 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         reset_database: Optional[bool]=None,
         indexer: Optional[Callable]=None,
         absolute_paths: Optional[bool]=None,
+        ignore: Optional[List[str]]=None,
+        force_index: Optional[List[str]]=None,
         **kwargs,
     ):
         if isinstance(root, Path):
             root = root.absolute()
-        self.dataset = load_dataset(root)
+
+        if ignore is None:
+            # If there is no .bidsignore file, apply default ignore patterns
+            if not (Path(root) / '.bidsignore').exists():
+                ignore = ['.*', 'models', 'stimuli', 'code', 'sourcedata']
+                warnings.warn(
+                    """ No .bidsignore file found. Setting default ignore patterns.
+                    In future versions of pybids a .bidsignore file will be 
+                    required to ignore files. """,
+                    DeprecationWarning
+                )
+
+        if force_index is not None:
+            warnings.warn(
+                "force_index no longer has any effect and will be removed",
+                DeprecationWarning
+            )
+
+        self.dataset = load_dataset(root, ignore=ignore)
         self.schema = self.dataset.get_schema()
         self.validationReport = None
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -363,10 +363,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         """
         path = convert_to_relative(self.dataset, path)
         file = self.dataset.get_file(path)
-        md = file.get_metadata()
-        if md and include_entities:
-            schema_entities = {e.literal_: e.name for e in list(self.schema.EntityEnum)}
-            md.update({schema_entities[e.key]: e.value for e in file.entities})
+        md = file.get_metadata(include_entities=include_entities, scope=scope)
         bmd = BIDSMetadata(file.get_absolute_path())
         bmd.update(md)
         return bmd

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -401,6 +401,8 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             values extracted from the filename.
         """
         results = parse_bids_name(filename)
+
+        ## Need to map entity literal to entity name
         entities = results.pop('entities')
         results = {**entities, **results}
 
@@ -734,7 +736,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                         cur_fieldmap["suffix"] = "fieldmap"
                     fieldmap_set.append(cur_fieldmap)
         return fieldmap_set
-        
+
     def add_derivatives(self, path):
         paths = listify(path)
         for path in paths:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -215,7 +215,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
     def __init__(
         self,
         root: Union[str, Path],
-        validate: bool=True,
+        validate: bool=False,
         derivatives: bool=False,
         config: Optional[Union[str, List[str]]]=None,
         sources: Optional[List[Any]]=None,

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -592,9 +592,11 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                     message = "Did you mean one of: {}?".format(suggestions)
                 else:
                     message = "Valid targets are: {}".format(potential)
+                    assert 0
                 raise TargetError(f"Unknown target '{target}'. {message}")  
+            target = target_match[0].name
         folder = self.dataset
-        result = query(folder, return_type, target_match[0].name, scope, extension, suffix, regex_search, **entities)
+        result = query(folder, return_type, target, scope, extension, suffix, regex_search, **entities)
         if return_type == 'files':
             result = natural_sort(result)
         if return_type == "object":
@@ -608,7 +610,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
     def entities(self):
         return self.get_entities()
 
-    def get_entities(self, scope: str = None, sort: bool = False) -> dict:
+    def get_entities(self, scope: str = None, sort: bool = False, long_form: bool = True) -> dict:
         """Returns a unique set of entities found within the dataset as a dict.
         Each key of the resulting dict contains a list of values (with at least one element).
 
@@ -626,13 +628,15 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             see BIDSLayout.get()
         sort: default is `False`
             whether to sort the keys by name
+        long_form: default is `True`
+            whether to return the long form of the entity name (e.g., 'subject' instead of 'sub')
 
         Returns
         -------
         dict
             a unique set of entities found within the dataset as a dict
         """
-        return query_entities(self.dataset, scope, sort)
+        return query_entities(self.dataset, scope, sort, long_form=long_form)
 
     def get_dataset_description(self, scope='self', all_=False) -> Union[List[Dict], Dict]:
         """Return contents of dataset_description.json.
@@ -770,8 +774,8 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
     def __repr__(self):
         """Provide a tidy summary of key properties."""
         ents = self.get_entities()
-        n_subjects = len(set(ents['sub'])) if 'sub' in ents else 0
-        n_sessions = len(set(ents['ses'])) if 'ses' in ents else 0
+        n_subjects = len(set(ents['subject'])) if 'subject' in ents else 0
+        n_sessions = len(set(ents['session'])) if 'session' in ents else 0
         n_runs = len(set(ents['run'])) if 'run' in ents else 0
         s = ("BIDS Layout: ...{} | Subjects: {} | Sessions: {} | "
              "Runs: {}".format(self.dataset.base_dir_, n_subjects, n_sessions, n_runs))

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -320,7 +320,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             pass
         if key.startswith('get_'):
             orig_ent_name = key.replace('get_', '')
-            ent_name = self.schema.fuzzy_match_entity_key(orig_ent_name)
+            ent_name = self.schema.fuzzy_match_entity(orig_ent_name).name
             if ent_name not in self.get_entities():
                 raise BIDSEntityError(
                     "'get_{}' can't be called because '{}' isn't a "
@@ -586,13 +586,12 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             target_match = [e for e in self.dataset._schema.EntityEnum 
                 if target in [e.name, e.literal_]]
             potential = list(self.get_entities().keys())
-            if (not target_match) or target_match[0].literal_ not in potential:
+            if (not target_match) or target_match[0].name not in potential:
                 suggestions = difflib.get_close_matches(target, potential)
                 if suggestions:
                     message = "Did you mean one of: {}?".format(suggestions)
                 else:
                     message = "Valid targets are: {}".format(potential)
-                    assert 0
                 raise TargetError(f"Unknown target '{target}'. {message}")  
             target = target_match[0].name
         folder = self.dataset
@@ -671,6 +670,9 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             the in-memory representation of this layout/dataset
         """
         return self.dataset
+
+    def get_fieldmap(self, path):
+        raise NotImplementedError
 
     def add_derivatives(self, path):
         path = convert_to_relative(self.dataset, path)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -533,6 +533,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
         """
         if regex_search is None:
             regex_search = self._regex_search
+
         # Provide some suggestions if target is specified and invalid.
         if return_type in ("dir", "id"):
             if target is None:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -581,23 +581,19 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
 
         # Provide some suggestions if target is specified and invalid.
         if return_type in ("dir", "id"):
-            if target is None:
-                raise TargetError(f'If return_type is "id" or "dir", a valid target '
-                                  'entity must also be specified.')
             # Resolve proper target names to their "key", e.g., session to ses
             # XXX should we allow ses?
-            target = getattr(self.dataset._schema.EntityEnum, target, target)
-            self_entities = self.get_entities()
-            if target not in self_entities:
-                potential = list(self_entities.keys())
+            target_match = getattr(self.dataset._schema.EntityEnum, target, None)
+            potential = list(self.get_entities().keys())
+            if (not target_match) or target_match.name not in potential:
                 suggestions = difflib.get_close_matches(target, potential)
                 if suggestions:
                     message = "Did you mean one of: {}?".format(suggestions)
                 else:
                     message = "Valid targets are: {}".format(potential)
-                raise TargetError(f"Unknown target '{target}'. {message}")
+                raise TargetError(f"Unknown target '{target}'. {message}")  
         folder = self.dataset
-        result = query(folder, return_type, target, scope, extension, suffix, regex_search, **entities)
+        result = query(folder, return_type, target_match.name, scope, extension, suffix, regex_search, **entities)
         if return_type == 'files':
             result = natural_sort(result)
         if return_type == "object":

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -256,7 +256,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
     def __init__(
         self,
         root: Union[str, Path],
-        validate: bool=False,
+        validate: bool=True,
         derivatives: bool=False,
         config: Optional[Union[str, List[str]]]=None,
         sources: Optional[List[Any]]=None,

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -320,9 +320,9 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.entity_: e.literal_ for e in list(self.schema.EntityEnum)}
+            schema_entities = {e.literal_: e.name for e in list(self.schema.EntityEnum)}
             md.update({schema_entities[e.key]: e.value for e in file.entities})
-        bmd = BIDSMetadata(file.path)
+        bmd = BIDSMetadata(file.get_absolute_path())
         bmd.update(md)
         return bmd
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -596,13 +596,14 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             target = target_match[0].name
         folder = self.dataset
         result = query(folder, return_type, target, scope, extension, suffix, regex_search, **entities)
-        if return_type == 'files':
+        if return_type == 'file':
             result = natural_sort(result)
         if return_type == "object":
-            result = natural_sort(
-                [BIDSFile(res) for res in result],
-                "path"
-            )
+            if result:
+                result = natural_sort(
+                    [BIDSFile(res) for res in result],
+                    "path"
+                )
         return result
 
     @property
@@ -675,8 +676,10 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         raise NotImplementedError
 
     def add_derivatives(self, path):
-        path = convert_to_relative(self.dataset, path)
-        self.dataset.create_derivative(path=path)
+        paths = listify(path)
+        for path in paths:
+            path = convert_to_relative(self.dataset, path)
+            self.dataset.create_derivative(path=path)
 
     def write_derivative(self, derivative):
         """Writes the provided derivative folder to the dataset.

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -198,7 +198,7 @@ class BIDSLayoutMRIMixin:
 
 
 
-class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariablesMixin):
+class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin):
     """A convenience class to provide access to an in-memory representation of a BIDS dataset.
 
     .. code-block::

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -139,8 +139,17 @@ class BIDSFile:
         """
         try:
             entities = self._artifact.get_entities()
+
+            # Convert literal entity values to their names
+            # TODO: Generalize this, as this is commmon throughout pybids
+            schema_entities = {e.literal_: e.name for e in list(self.schema.EntityEnum)}
+            entities = {schema_entities[k]: v for k, v in entities.items()}
+            entities['suffix'] = self._artifact.suffix
+            entities['extension'] = self._artifact.extension
+            
             if metadata:
-                entities = {**entities, **self._artifact.get_metadata()}
+                entities = {**entities, **self._artifact.get_metadata(), 
+                **self._artifact.suffix}
         except AttributeError:
             raise NotImplementedError
         

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -141,15 +141,13 @@ class BIDSFile:
             entities = self._artifact.get_entities()
 
             # Convert literal entity values to their names
-            # TODO: Generalize this, as this is commmon throughout pybids
-            schema_entities = {e.literal_: e.name for e in list(self.schema.EntityEnum)}
-            entities = {schema_entities[k]: v for k, v in entities.items()}
+            # schema_entities = {e.literal_: e.name for e in list(self.schema.EntityEnum)}
+            # entities = {schema_entities[k]: v for k, v in entities.items()}
             entities['suffix'] = self._artifact.suffix
             entities['extension'] = self._artifact.extension
-            
+
             if metadata:
-                entities = {**entities, **self._artifact.get_metadata(), 
-                **self._artifact.suffix}
+                entities = {**entities, **self._artifact.get_metadata()}
         except AttributeError:
             raise NotImplementedError
         

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -10,13 +10,13 @@ from bids.tests import get_test_data_path
 @pytest.fixture(scope="module")
 def layout_7t_trt():
     data_dir = join(get_test_data_path(), '7t_trt')
-    return BIDSLayout(data_dir, validate=False)
+    return BIDSLayout(data_dir)
 
 
 @pytest.fixture(scope="module")
 def layout_7t_trt_relpath():
     data_dir = join(get_test_data_path(), '7t_trt')
-    return BIDSLayout(data_dir, absolute_paths=False, validate=False)
+    return BIDSLayout(data_dir, absolute_paths=False)
 
 
 @pytest.fixture(scope="module")

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -10,13 +10,13 @@ from bids.tests import get_test_data_path
 @pytest.fixture(scope="module")
 def layout_7t_trt():
     data_dir = join(get_test_data_path(), '7t_trt')
-    return BIDSLayout(data_dir)
+    return BIDSLayout(data_dir, validate=False)
 
 
 @pytest.fixture(scope="module")
 def layout_7t_trt_relpath():
     data_dir = join(get_test_data_path(), '7t_trt')
-    return BIDSLayout(data_dir, absolute_paths=False)
+    return BIDSLayout(data_dir, absolute_paths=False, validate=False)
 
 
 @pytest.fixture(scope="module")

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -3,9 +3,8 @@ BIDSLayout class."""
 
 import json
 import os
-import re
 import shutil
-from os.path import join, abspath, basename
+from os.path import join, abspath
 from pathlib import Path
 
 import numpy as np
@@ -17,10 +16,7 @@ from bids.exceptions import (
     NoMatchError,
     TargetError,
 )
-from bids.layout import BIDSLayout, Query
-from bids.layout.index import BIDSLayoutIndexer
-from bids.layout.models import Config
-from bids.layout.utils import PaddedInt
+from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
 

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -232,7 +232,7 @@ def test_get_metadata_error(layout_7t_trt):
 
 def test_get_with_bad_target(layout_7t_trt):
     with pytest.raises(TargetError) as exc:
-        layout_7t_trt.get(target='unicorn')
+        layout_7t_trt.get(target='unicorn', return_type='id')
     msg = str(exc.value)
     assert 'subject' in msg and 'reconstruction' in msg and 'proc' in msg
     with pytest.raises(TargetError) as exc:

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -290,7 +290,7 @@ def test_get_return_type_dir(layout_7t_trt):
 def test_get_val_none(layout_7t_trt):
     t1w_files = layout_7t_trt.get(subject='01', session='1', suffix='T1w')
     assert len(t1w_files) == 1
-    assert 'acq' not in t1w_files[0].name
+    assert 'acq' not in t1w_files[0].path
     t1w_files = layout_7t_trt.get(
         subject='01', session='1', suffix='T1w', acquisition=None)
     assert len(t1w_files) == 1

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -358,18 +358,18 @@ def test_layout_with_multi_derivs(layout_ds005_multi_derivs):
 def test_query_derivatives(layout_ds005_derivs):
     result = layout_ds005_derivs.get(suffix='events', return_type='object',
                                      extension='.tsv')
-    result = [f.name for f in result]
+    result = [f.path for f in result]
     assert len(result) == 49
     assert 'sub-01_task-mixedgamblestask_run-01_desc-extra_events.tsv' in result
     result = layout_ds005_derivs.get(suffix='events', return_type='object',
                                      scope='raw', extension='.tsv')
     assert len(result) == 48
-    result = [f.name for f in result]
+    result = [f.path for f in result]
     assert 'sub-01_task-mixedgamblestask_run-01_desc-extra_events.tsv' not in result
     result = layout_ds005_derivs.get(suffix='events', return_type='object',
                                      desc='extra', extension='.tsv')
     assert len(result) == 1
-    result = [f.name for f in result]
+    result = [f.path for f in result]
     assert 'sub-01_task-mixedgamblestask_run-01_desc-extra_events.tsv' in result
 
 

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -1,18 +1,14 @@
 """Tests of functionality in the models module."""
 
-import sys
 import os
 import pytest
 import copy
 import json
 from pathlib import Path
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 import numpy as np
 
-from bids.layout.models import (BIDSFile, Entity, Tag, Base, Config,
-                                FileAssociation, BIDSImageFile, LayoutInfo)
+from bids.layout.models import (BIDSFile, BIDSImageFile)
 from bids.layout.utils import PaddedInt
 from bids.tests import get_test_data_path
 

--- a/bids/layout/tests/test_utils.py
+++ b/bids/layout/tests/test_utils.py
@@ -6,7 +6,6 @@ import pytest
 import bids
 from bids.exceptions import ConfigError
 
-from ..models import Entity, Config
 from ..utils import BIDSMetadata, add_config_paths
 
 
@@ -17,36 +16,6 @@ def test_bidsmetadata_class():
     assert "Metadata term 'Missing' unavailable for file fakefile." in str(err)
     md["Missing"] = 1
     assert md["Missing"] == 1
-
-
-def test_parse_file_entities(mock_config):
-    filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
-
-    # Test with entities taken from bids config
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'extension': '.nii.gz'}
-    assert target == parse_file_entities(filename, config='bids')
-    config = Config.load('bids')
-    assert target == parse_file_entities(filename, config=[config])
-
-    # Test with entities taken from bids and derivatives config
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'desc': 'bleargh', 'extension': '.nii.gz'}
-    assert target == parse_file_entities(filename)
-    assert target == parse_file_entities(
-        filename, config=['bids', 'derivatives'])
-
-    # Test with list of Entities
-    entities = [
-        Entity('subject', "[/\\\\]sub-([a-zA-Z0-9]+)"),
-        Entity('run', "[_/\\\\]run-0*(\\d+)", dtype=int),
-        Entity('suffix', "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"),
-        Entity('desc', "desc-([a-zA-Z0-9]+)"),
-    ]
-    # Leave out session to distinguish from previous test target
-    target = {'subject': '03', 'run': 4, 'suffix': 'sekret', 'desc': 'bleargh'}
-    assert target == parse_file_entities(filename, entities=entities)
-
 
 def test_add_config_paths():
     bids_dir = os.path.dirname(bids.__file__)

--- a/bids/layout/tests/test_writing.py
+++ b/bids/layout/tests/test_writing.py
@@ -9,7 +9,7 @@ import pytest
 from bids.layout.writing import build_path, _PATTERN_FIND
 from bids.tests import get_test_data_path
 from bids import BIDSLayout
-from bids.layout.models import BIDSFile, Entity, Tag, Base
+from bids.layout.models import BIDSFile
 
 
 @pytest.fixture


### PR DESCRIPTION
- Temporarily default to `validate=False` to try running tests
- Clean up unused imports
- FIX: `get_metadata` with entities
- FIX: Change test to only expect TargetError when return_type = 'id' or 'dir'
- FIX: Throw error in `__getattr__` if `get_{entity}` does not match a known entity in dataset (rather than throwing another obscure error). 
- FIX: in `.get`, look for potential target matches in `EntityEnum` in both `.name` and `.literal_`
- closes #27 