### PR TITLE
Change get_metadata to return long-name 

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -354,9 +354,9 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.entity_: e.literal_ for e in list(self.schema.EntityEnum)}
+            schema_entities = {e.literal_: e.display_name_ for e in list(self.schema.EntityEnum)}
             md.update({schema_entities[e.key]: e.value for e in file.entities})
-        bmd = BIDSMetadata(file.path)
+        bmd = BIDSMetadata(file['name'])
         bmd.update(md)
         return bmd
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -354,8 +354,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.value['name']: e.name for e in list(self.schema.EntityEnum)}
-            md.update({schema_entities[e.key]: e.value for e in file.entities})
+            md.update(file.entities)
         bmd = BIDSMetadata(file['name'])
         bmd.update(md)
         return bmd
@@ -574,6 +573,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                                   'entity must also be specified.')
             # Resolve proper target names to their "key", e.g., session to ses
             # XXX should we allow ses?
+            assert 0
             self_entities = self.get_entities()
             if target not in self_entities:
                 potential = list(self_entities.keys())
@@ -622,7 +622,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         dict
             a unique set of entities found within the dataset as a dict
         """
-        return query_entities(self.dataset, scope, sort)
+        return query_entities(self.dataset, scope, sort, long_form=True)
 
     def get_dataset_description(self, scope='self', all_=False) -> Union[List[Dict], Dict]:
         """Return contents of dataset_description.json.

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -354,7 +354,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.literal_: e.display_name_ for e in list(self.schema.EntityEnum)}
+            schema_entities = {e.name: e.value['display_name'] for e in list(self.schema.EntityEnum)}
             md.update({schema_entities[e.key]: e.value for e in file.entities})
         bmd = BIDSMetadata(file['name'])
         bmd.update(md)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -602,21 +602,12 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
 
         # Provide some suggestions if target is specified and invalid.
         if return_type in ("dir", "id"):
-<<<<<<< HEAD
             if target is None:
                 raise TargetError(f'If return_type is "id" or "dir", a valid target '
                                   'entity must also be specified.')
             self_entities = self.get_entities()
             if target not in self_entities:
                 potential = list(self_entities.keys())
-=======
-            # Resolve proper target names to their "key", e.g., session to ses
-            # XXX should we allow ses?
-            target_match = [e for e in self.dataset._schema.EntityEnum 
-                if target in [e.name, e.literal_]]
-            potential = list(self.get_entities().keys())
-            if (not target_match) or target_match[0].name not in potential:
->>>>>>> rf/ancp-layout
                 suggestions = difflib.get_close_matches(target, potential)
                 if suggestions:
                     message = "Did you mean one of: {}?".format(suggestions)
@@ -666,11 +657,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         dict
             a unique set of entities found within the dataset as a dict
         """
-<<<<<<< HEAD
-        return query_entities(self.dataset, scope, sort, long_form=True)
-=======
         return query_entities(self.dataset, scope, sort, long_form=long_form)
->>>>>>> rf/ancp-layout
 
     def get_dataset_description(self, scope='self', all_=False) -> Union[List[Dict], Dict]:
         """Return contents of dataset_description.json.

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -571,9 +571,6 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             if target is None:
                 raise TargetError(f'If return_type is "id" or "dir", a valid target '
                                   'entity must also be specified.')
-            # Resolve proper target names to their "key", e.g., session to ses
-            # XXX should we allow ses?
-            assert 0
             self_entities = self.get_entities()
             if target not in self_entities:
                 potential = list(self_entities.keys())

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -354,7 +354,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.literal_: e.display_name_ for e in list(self.schema.EntityEnum)}
+            schema_entities = {e.value['name']: e.name for e in list(self.schema.EntityEnum)}
             md.update({schema_entities[e.key]: e.value for e in file.entities})
         bmd = BIDSMetadata(file['name'])
         bmd.update(md)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -421,7 +421,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         results = parse_bids_name(filename)
 
         entities = results.pop('entities')
-        schema_entities = {e.literal_: e.name for e in list(self.schema.EntityEnum)}
+        schema_entities = {e.value['name']: e.name for e in list(self.schema.EntityEnum)}
         entities = {schema_entities[k]: v for k, v in entities.items()}
         results = {**entities, **results}
 
@@ -614,7 +614,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                 else:
                     message = "Valid targets are: {}".format(potential)
                 raise TargetError(f"Unknown target '{target}'. {message}")  
-            target = target_match[0].name
+
         folder = self.dataset
         result = query(folder, return_type, target, scope, extension, suffix, regex_search, **entities)
         if return_type == 'file':
@@ -622,7 +622,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         if return_type == "object":
             if result:
                 result = natural_sort(
-                    [BIDSFile(res) for res in result],
+                    [BIDSFile(res, schema=self.schema) for res in result],
                     "path"
                 )
         return result

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -18,7 +18,7 @@ from ..exceptions import (
 )
 
 from ancpbids import CustomOpExpr, EntityExpr, AllExpr, ValidationPlugin, load_dataset, validate_dataset, \
-    write_derivative
+    write_derivative, DatasetOptions
 from ancpbids.query import query, query_entities, FnMatchExpr, AnyExpr
 from ancpbids.utils import deepupdate, resolve_segments, convert_to_relative, parse_bids_name
 
@@ -274,7 +274,6 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
             root = root.absolute()
 
         if ignore is None:
-            # If there is no .bidsignore file, apply default ignore patterns
             if not (Path(root) / '.bidsignore').exists():
                 ignore = ['.*', 'models', 'stimuli', 'code', 'sourcedata']
                 warnings.warn(
@@ -290,7 +289,9 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                 DeprecationWarning
             )
 
-        self.dataset = load_dataset(root, ignore=ignore)
+        options = DatasetOptions(ignore=ignore)
+
+        self.dataset = load_dataset(root, options=options)
         self.schema = self.dataset.get_schema()
         self.validationReport = None
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -622,7 +622,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         if return_type == "object":
             if result:
                 result = natural_sort(
-                    [BIDSFile(res, schema=self.schema) for res in result],
+                    [BIDSFile(res) for res in result],
                     "path"
                 )
         return result

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -574,7 +574,6 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                                   'entity must also be specified.')
             # Resolve proper target names to their "key", e.g., session to ses
             # XXX should we allow ses?
-            target = getattr(self.dataset._schema.EntityEnum, target, target)
             self_entities = self.get_entities()
             if target not in self_entities:
                 potential = list(self_entities.keys())

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -37,13 +37,14 @@ class BIDSFile:
                 break
         return cls(path)
 
-    def __init__(self, file_ref: Union[str, os.PathLike, Artifact], schema):
+    def __init__(self, file_ref: Union[str, os.PathLike, Artifact], schema = None):
         self._path = None
         self._artifact = None
-        self._schema = schema # Adding this to be able to convert metadata
+        self._schema = schema
         if isinstance(file_ref, (str, os.PathLike)):
             self._path = Path(file_ref)
         elif isinstance(file_ref, Artifact):
+            self._schema = file_ref.get_schema()
             self._artifact = file_ref
         
     @property

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -202,8 +202,8 @@ def test_get_metadata5(layout_7t_trt):
     result = layout_7t_trt.get_metadata(
         join(layout_7t_trt.root, *target), include_entities=True)
     assert result['EchoTime'] == 0.020
-    assert result['Subject'] == '01'
-    assert result['Acquisition'] == 'fullbrain'
+    assert result['subject'] == '01'
+    assert result['acquisition'] == 'fullbrain'
 
 
 def test_get_metadata_via_bidsfile(layout_7t_trt):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -336,8 +336,8 @@ def test_layout_with_derivs(layout_ds005_derivs):
     event_file = "sub-01_task-mixedgamblestask_run-01_desc-extra_events.tsv"
     deriv_files = [f.name for f in files]
     assert event_file in deriv_files
-    entities = deriv.query_entities()
-    assert 'sub' in entities
+    entities = deriv.query_entities(long_form=True)
+    assert 'subject' in entities
 
 
 def test_layout_with_multi_derivs(layout_ds005_multi_derivs):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -236,7 +236,7 @@ def test_get_with_bad_target(layout_7t_trt):
     msg = str(exc.value)
     assert 'subject' in msg and 'reconstruction' in msg and 'proc' in msg
     with pytest.raises(TargetError) as exc:
-        layout_7t_trt.get(target='sub')
+        layout_7t_trt.get(target='subject')
     msg = str(exc.value)
     assert 'subject' in msg and 'reconstruction' not in msg
 
@@ -282,7 +282,7 @@ def test_bids_json(layout_7t_trt):
 
 
 def test_get_return_type_dir(layout_7t_trt):
-    res_relpath = layout_7t_trt.get(target='sub', return_type='dir')
+    res_relpath = layout_7t_trt.get(target='subject', return_type='dir')
     target_relpath = ["sub-{:02d}".format(i) for i in range(1, 11)]
     assert all([tp in res_relpath for tp in target_relpath])
 
@@ -322,7 +322,7 @@ def test_get_val_enum_any_optional(layout_7t_trt, layout_ds005):
 
 
 def test_get_return_sorted(layout_7t_trt):
-    paths = layout_7t_trt.get(target='sub', return_type='file')
+    paths = layout_7t_trt.get(target='subject', return_type='file')
     assert natural_sort(paths) == paths
 
 

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -17,10 +17,7 @@ from bids.exceptions import (
     NoMatchError,
     TargetError,
 )
-from bids.layout import BIDSLayout, Query
-from bids.layout.index import BIDSLayoutIndexer
-from bids.layout.models import Config
-from bids.layout.utils import PaddedInt
+from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
 
@@ -205,8 +202,8 @@ def test_get_metadata5(layout_7t_trt):
     result = layout_7t_trt.get_metadata(
         join(layout_7t_trt.root, *target), include_entities=True)
     assert result['EchoTime'] == 0.020
-    assert result['subject'] == '01'
-    assert result['acquisition'] == 'fullbrain'
+    assert result['Subject'] == '01'
+    assert result['Acquisition'] == 'fullbrain'
 
 
 def test_get_metadata_via_bidsfile(layout_7t_trt):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "bids-validator",
   "num2words",
   "click >=8.0",
+  "ancpbids @ git+https://github.com/adelavega/ancp-bids.git",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
- Fixes #25,
- Handles entities "key" as the name, instead of then "name". E.g. "subject" instead of "sub".
- Update to use DatasetOption in ancpbids

Depends on ancpbids bug fix: https://github.com/ANCPLabOldenburg/ancp-bids/pull/74