### PR TITLE
FIX: Incorrect entitity key match in return_type='id'

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -354,9 +354,9 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.entity_: e.literal_ for e in list(self.schema.EntityEnum)}
+            schema_entities = {e.literal_: e.display_name_ for e in list(self.schema.EntityEnum)}
             md.update({schema_entities[e.key]: e.value for e in file.entities})
-        bmd = BIDSMetadata(file.path)
+        bmd = BIDSMetadata(file['name'])
         bmd.update(md)
         return bmd
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -354,7 +354,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.literal_: e.display_name_ for e in list(self.schema.EntityEnum)}
+            schema_entities = {e.name: e.value['display_name'] for e in list(self.schema.EntityEnum)}
             md.update({schema_entities[e.key]: e.value for e in file.entities})
         bmd = BIDSMetadata(file['name'])
         bmd.update(md)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -574,7 +574,6 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
                                   'entity must also be specified.')
             # Resolve proper target names to their "key", e.g., session to ses
             # XXX should we allow ses?
-            target = getattr(self.dataset._schema.EntityEnum, target, target)
             self_entities = self.get_entities()
             if target not in self_entities:
                 potential = list(self_entities.keys())

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -17,10 +17,7 @@ from bids.exceptions import (
     NoMatchError,
     TargetError,
 )
-from bids.layout import BIDSLayout, Query
-from bids.layout.index import BIDSLayoutIndexer
-from bids.layout.models import Config
-from bids.layout.utils import PaddedInt
+from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
 
@@ -205,8 +202,8 @@ def test_get_metadata5(layout_7t_trt):
     result = layout_7t_trt.get_metadata(
         join(layout_7t_trt.root, *target), include_entities=True)
     assert result['EchoTime'] == 0.020
-    assert result['subject'] == '01'
-    assert result['acquisition'] == 'fullbrain'
+    assert result['Subject'] == '01'
+    assert result['Acquisition'] == 'fullbrain'
 
 
 def test_get_metadata_via_bidsfile(layout_7t_trt):


### PR DESCRIPTION
Fixes #25 

However, I still think the question of what the correct key for entities should be is open ("literal", or "key", or both?).

See: https://github.com/bids-standard/pybids-refactor/issues/8