### PR TITLE
Add ignore

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -18,7 +18,7 @@ from ..exceptions import (
 )
 
 from ancpbids import CustomOpExpr, EntityExpr, AllExpr, ValidationPlugin, load_dataset, validate_dataset, \
-    write_derivative
+    write_derivative, DatasetOptions
 from ancpbids.query import query, query_entities, FnMatchExpr, AnyExpr
 from ancpbids.utils import deepupdate, resolve_segments, convert_to_relative, parse_bids_name
 
@@ -264,11 +264,18 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         database_path: Optional[str]=None,
         reset_database: Optional[bool]=None,
         indexer: Optional[Callable]=None,
+        ignore: Optional[List[str]]=None,
         **kwargs,
     ):
         if isinstance(root, Path):
             root = root.absolute()
-        self.dataset = load_dataset(root)
+
+        if ignore is None:
+            ignore = ["code", "stimuli", "sourcedata", "models"]
+
+        options = DatasetOptions(ignore=ignore)
+        
+        self.dataset = load_dataset(root, options=options)
         self.schema = self.dataset.get_schema()
         self.validationReport = None
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -354,7 +354,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         file = self.dataset.get_file(path)
         md = file.get_metadata()
         if md and include_entities:
-            schema_entities = {e.literal_: e.display_name_ for e in list(self.schema.EntityEnum)}
+            schema_entities = {e.value['name']: e.name for e in list(self.schema.EntityEnum)}
             md.update({schema_entities[e.key]: e.value for e in file.entities})
         bmd = BIDSMetadata(file['name'])
         bmd.update(md)

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -17,10 +17,7 @@ from bids.exceptions import (
     NoMatchError,
     TargetError,
 )
-from bids.layout import BIDSLayout, Query
-from bids.layout.index import BIDSLayoutIndexer
-from bids.layout.models import Config
-from bids.layout.utils import PaddedInt
+from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
 

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -202,8 +202,8 @@ def test_get_metadata5(layout_7t_trt):
     result = layout_7t_trt.get_metadata(
         join(layout_7t_trt.root, *target), include_entities=True)
     assert result['EchoTime'] == 0.020
-    assert result['Subject'] == '01'
-    assert result['Acquisition'] == 'fullbrain'
+    assert result['subject'] == '01'
+    assert result['acquisition'] == 'fullbrain'
 
 
 def test_get_metadata_via_bidsfile(layout_7t_trt):


### PR DESCRIPTION
Adds `ignore` to `BIDSLayout`.

Ignores default set of directories. Does not ignore hidden files as `ancpbids` only support list of directories, not regex patterns (I don't think).

I merged #30 and #31 in here, so depends on those