### PR TITLE
Get all meta-data keys in dataset

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -631,7 +631,7 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
     def entities(self):
         return self.get_entities()
 
-    def get_entities(self, scope: str = None, sort: bool = False, long_form: bool = True) -> dict:
+    def get_entities(self, scope: str = None, sort: bool = False, long_form: bool = True, metadata: bool = False) -> dict:
         """Returns a unique set of entities found within the dataset as a dict.
         Each key of the resulting dict contains a list of values (with at least one element).
 
@@ -657,7 +657,14 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         dict
             a unique set of entities found within the dataset as a dict
         """
-        return query_entities(self.dataset, scope, sort, long_form=long_form)
+
+        entities = query_entities(self.dataset, scope, sort, long_form=long_form)
+
+        metadata = {}
+        if metadata is True:
+            metadata = self._get_metadata_keys()
+            
+        return {**entities, **metadata}
 
     def _get_metadata_keys(self):
         """Return a list of all metadata keys found in the dataset."""

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -659,6 +659,17 @@ class BIDSLayout(BIDSLayoutMRIMixin, BIDSLayoutWritingMixin, BIDSLayoutVariables
         """
         return query_entities(self.dataset, scope, sort, long_form=long_form)
 
+    def _get_metadata_keys(self):
+        """Return a list of all metadata keys found in the dataset."""
+        
+        all_metadata_objects = self.dataset.select(self.schema.MetadataArtifact).objects()
+
+        keys = set()
+        for obj in all_metadata_objects:
+            keys.update(obj['contents'].keys())
+
+        return keys
+
     def get_dataset_description(self, scope='self', all_=False) -> Union[List[Dict], Dict]:
         """Return contents of dataset_description.json.
 


### PR DESCRIPTION
`get_entities(metadata=True)` returns all entity's unique values AND all meta-data unique values, computed on the fly.

This is used in the `__repr__` function to determine which functions to respond to (i.e. `get_RepetitionTime`).

There are various possible optimizations here to prevent unnecessary computation, such as memoizing, and only computing meta-data if normal entities don't match. 

Related #37 

Depends on #30, so merging into that PR